### PR TITLE
Check if spack is found before calling spack unload in minimal env files

### DIFF
--- a/envs/gnu10/gcclassic.rocky+gnu10.minimal.env
+++ b/envs/gnu10/gcclassic.rocky+gnu10.minimal.env
@@ -21,7 +21,7 @@ module purge
 
 # Unload packages loaded with "spack load"
 if [[ "x${SPACK_ROOT}" != "x" ]]; then
-    spack unload --all
+    which spack &> /dev/null || spack unload --all
 fi
 
 #==============================================================================

--- a/envs/gnu10/gchp.rocky+gnu10.minimal.env
+++ b/envs/gnu10/gchp.rocky+gnu10.minimal.env
@@ -21,7 +21,7 @@ module purge
 
 # Unload packages loaded with "spack load"
 if [[ "x${SPACK_ROOT}" != "x" ]]; then
-    spack unload --all
+    which spack &> /dev/null || spack unload --all
 fi
 
 #==============================================================================

--- a/envs/gnu12/gcclassic.rocky+gnu12.minimal.env
+++ b/envs/gnu12/gcclassic.rocky+gnu12.minimal.env
@@ -21,7 +21,7 @@ module purge
 
 # Unload packages loaded with "spack load"
 if [[ "x${SPACK_ROOT}" != "x" ]]; then
-    spack unload --all
+    which spack &> /dev/null || spack unload --all
 fi
 
 #==============================================================================

--- a/envs/gnu12/gchp.rocky+gnu12.minimal.env
+++ b/envs/gnu12/gchp.rocky+gnu12.minimal.env
@@ -21,7 +21,7 @@ module purge
 
 # Unload packages loaded with "spack load"
 if [[ "x${SPACK_ROOT}" != "x" ]]; then
-    spack unload --all
+    which spack &> /dev/null || spack unload --all
 fi
 
 #==============================================================================

--- a/envs/intel23/gcclassic.rocky+intel23.minimal.env
+++ b/envs/intel23/gcclassic.rocky+intel23.minimal.env
@@ -21,7 +21,7 @@ module purge
 
 # Unload packages loaded with "spack load"
 if [[ "x${SPACK_ROOT}" != "x" ]]; then
-    spack unload --all
+    which spack &> /dev/null || spack unload --all
 fi
 
 #==============================================================================

--- a/envs/intel23/gchp.rocky+intel23.minimal.env
+++ b/envs/intel23/gchp.rocky+intel23.minimal.env
@@ -21,7 +21,7 @@ module purge
 
 # Unload packages loaded with "spack load"
 if [[ "x${SPACK_ROOT}" != "x" ]]; then
-    spack unload --all
+    which spack &> /dev/null || spack unload --all
 fi
 
 #==============================================================================


### PR DESCRIPTION
This update prevents an error return code on the spack unload call which can cause scripts that source the env file to fail early. This was happening with GCHP script gchp.local.run if the spack library was not already loaded. Since the minimal
envs do not use spack they should not require spack to be loaded.